### PR TITLE
Round of changes dealing with search_api alpha to beta.

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,0 +1,46 @@
+INSTALLING MODULES AND LIBRARIES
+--------------------------------
+ * Download the module and all of its dependencies. Move them to the contributed
+   modules location in your tree (e.g. /modules/ or /modules/contrib/).
+
+ * Install Algolia search client PHP library from https://github.com/algolia
+   /algoliasearch-client-php via command line `composer require algolia/algoliasearch-client-php`
+
+ * Enable the module's dependencies on the modules admin page url (/admin/modules).
+
+
+CONFIGURING SEARCH API SERVER AND INDEX
+---------------------------------------
+
+ * On the Search API administration page (/admin/config/search/search-api), add
+   a new server, select backend "Algolia", and check the "Enabled" checkbox.
+   In the "Configure Algolia backend" section, fill in your Application ID and API key found in your Algolia dashboard on
+   https://www.algolia.com.
+
+ * On the Search API administration page (/admin/config/search/search_api), add
+   a new index, enable it and select the server you just created in the previous
+   section. The index name provided will be used to create a new index on the
+   Algolia platform. Please read the "Known problems" section of the README.txt
+   file for the latest updates about the type of entity supported.
+
+ * On the "Fields" tab of your index
+   (/admin/config/search/search_api/index/[YOUR INDEX NAME]/fields), check all
+   the fields you want to have indexed in the Algolia index. At the very least,
+   the entity ID field for the indexed entity type needs to be checked off (nid
+   for nodes, uid for users, etc.). Please read the "Known problems" section of
+   the README.txt file for the latest updates about the type of fields
+   supported.
+
+ * On the "Processors" of your index (/admin/config/search/search_api/index/[YOUR
+   INDEX NAME]/processors), select the processors you want to apply before the data
+   is being sent to Algolia's servers. A good starting combination could be
+   "Entity status" (allowing you to Exclude unpublished content, unpublished comments and inactive users from being indexed.
+   Please read the "Known problems" section of the README.txt file for
+   the latest updates about the type of processor supported.
+
+
+INDEXING CONTENT
+----------------
+* On your newly created index page, (/admin/config/search/search_api/index/[YOUR
+  INDEX NAME]), click the "Index now" button. You should start seeing content
+  populating the index in the Algolia dashboard on https://www.algolia.com.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,0 @@
-# Algolia search with Search API
-Drupal 8 version Search API implementation to Algolia
-
-To install:
-composer require algolia/algoliasearch-client-php
-Then enable the module. 
-
-I will have to look into a way to the download during install. But there seems to be some issues that need to be addressed here first https://www.drupal.org/node/2477789

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,72 @@
+CONTENTS OF THIS FILE
+---------------------
+ * Introduction
+ * Requirements
+ * Installation
+ * Known problems
+ * Maintainers
+ * Dependencies
+
+
+INTRODUCTION
+------------
+This module provides integration with the Algolia service
+(https://www.algolia.com), through Drupal's Search API. This module is intended
+to be used by developers, as it does not currently provide any implementation of
+an actual search interface. Only indexing is currently supported. As a result,
+enabling that module will not have any visible effect on your application.
+Search functionality may be implemented using the Algolia Javascript API.
+
+Currently supported:
+ * initial indexing of entities (see "Know problems")
+ * re-indexing on node updates or through forced re-index action
+
+Type of fields which have been successfully tested:
+ * entity reference fields (either single or multivalued)
+ * standard text fields containing either strings or integers (integer support
+   is important for comparison functions in the search query)
+ * geofield, address field components
+
+
+REQUIREMENTS
+------------
+This module requires the following modules:
+ * Search API (https://www.drupal.org/project/search_api)
+
+This module also uses the following library:
+ * Algolia search client PHP library
+   https://github.com/algolia/algoliasearch-client-php
+   add via `composer require algolia/algoliasearch-client-php`
+
+
+INSTALLATION
+------------
+Please refer to the INSTALL.txt file.
+
+
+KNOWN PROBLEMS
+--------------
+Please report problems.
+
+
+MAINTAINERS
+-----------
+
+Current D7 maintainers:
+Matthieu Bergel (mbrgl) - https://www.drupal.org/user/489214
+
+Current D8 maintainers:
+Jens Beltofte (beltofte) - https://www.drupal.org/u/beltofte
+Christopher Calip (chriscalip) - https://www.drupal.org/u/chriscalip
+
+The initial Drupal 7 development of this module has been sponsored by TroisCube (http://www.troiscube.com).
+The initial Drupal 8 development of this module has been sponsored by FDM.dk and FFWagency.com
+
+DEPENDENCIES
+------------
+This module requires an account on https://www.algolia.com, where you will be
+able to generate the required Application ID and API key. A 14-day free trial
+period is granted with every new account.
+
+Pricing options can be found on the Algolia website:
+https://www.algolia.com/pricing

--- a/search_api_algolia.install
+++ b/search_api_algolia.install
@@ -1,5 +1,9 @@
 <?php
 
+ /**
+  * @file
+  */
+
 /**
  * Implements hook_requirements().
  */

--- a/search_api_algolia.module
+++ b/search_api_algolia.module
@@ -5,4 +5,4 @@
  * Provides an Algolia Search based service class for the Search API.
  */
 
-use Drupal\search_api_algolia\Plugin\search_api\backend;
+/* use Drupal\search_api_algolia\Plugin\search_api\backend; */

--- a/search_api_algolia.services.yml
+++ b/search_api_algolia.services.yml
@@ -1,0 +1,4 @@
+services:
+  logger.channel.search_api_algolia:
+    parent: logger.channel_base
+    arguments: ['search_api_algolia']

--- a/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
@@ -1,23 +1,17 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\search_api_algolia\Plugin\search_api\backend\SearchApiAlgoliaBackend.
- */
-
 namespace Drupal\search_api_algolia\Plugin\search_api\backend;
 
+use AlgoliaSearch\Client;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Field;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\search_api\Backend\BackendPluginBase;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\IndexInterface;
 use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\search_api\Query\QueryInterface;
-use Drupal\search_api\Utility;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -28,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   description = @Translation("Index items using a Algolia Search.")
  * )
  */
-class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormInterface {
+class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInterface {
 
   use PluginFormTrait;
 
@@ -129,19 +123,19 @@ class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormIn
     }
     $info = array();
 
-    // Application ID
+    // Application ID.
     $info[] = array(
       'label' => $this->t('Application ID'),
       'info' => $this->getApplicationId(),
     );
 
-    // API Key
+    // API Key.
     $info[] = array(
       'label' => $this->t('API Key'),
       'info' => $this->getApiKey(),
     );
 
-    // Available indexes
+    // Available indexes.
     $indexes = $this->getAlgolia()->listIndexes();
     $indexes_list = array();
     if (isset($indexes['items'])) {
@@ -335,7 +329,7 @@ class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormIn
    */
   protected function connect($index = NULL) {
     if (!$this->getAlgolia()) {
-      $this->algoliaClient = new \AlgoliaSearch\Client($this->getApplicationId(), $this->getApiKey());
+      $this->algoliaClient = new Client($this->getApplicationId(), $this->getApiKey());
 
       if ($index && $index instanceof IndexInterface) {
         $this->setAlgoliaIndex($this->algoliaClient->initIndex($index->get('id')));
@@ -426,4 +420,5 @@ class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormIn
   protected function getApiKey() {
     return $this->configuration['api_key'];
   }
+
 }

--- a/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
@@ -11,10 +11,12 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\search_api\Backend\BackendPluginBase;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\search_api\Query\QueryInterface;
-use Drupal\search_api\Backend\BackendPluginBase;
 use Drupal\search_api\Utility;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -26,7 +28,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   description = @Translation("Index items using a Algolia Search.")
  * )
  */
-class SearchApiAlgoliaBackend extends BackendPluginBase {
+class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormInterface {
+
+  use PluginFormTrait;
 
   protected $algoliaIndex = NULL;
 

--- a/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
@@ -225,7 +225,11 @@ class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormIn
     foreach ($item_fields as $field_id => $field) {
       $type = $field->getType();
       $values = NULL;
-      foreach ($field->getValues() as $field_value) {
+      $field_values = $field->getValues();
+      if (empty($field_values)) {
+        continue;
+      }
+      foreach ($field_values as $field_value) {
         if (!$field_value) {
           continue;
         }
@@ -262,7 +266,7 @@ class SearchApiAlgoliaBackend extends BackendPluginBase  implements PluginFormIn
             $values[] = $field_value;
         }
       }
-      if (count($values) <= 1) {
+      if (is_array($values) && count($values) <= 1) {
         $values = reset($values);
       }
       $item_to_index[$field->getFieldIdentifier()] = $values;

--- a/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
+++ b/src/Plugin/search_api/backend/SearchApiAlgoliaBackend.php
@@ -77,20 +77,20 @@ class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInt
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
-    return array(
+    return [
       'application_id' => '',
       'api_key' => '',
-    );
+    ];
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
-    $form['help'] = array(
-      '#markup' => '<p>' . $this->t('The application ID and API key an be found and configured at <a href="@link" target="blank">@link</a>.', array('@link' => 'https://www.algolia.com/licensing')) . '</p>',
-    );
-    $form['application_id'] = array(
+    $form['help'] = [
+      '#markup' => '<p>' . $this->t('The application ID and API key an be found and configured at <a href="@link" target="blank">@link</a>.', ['@link' => 'https://www.algolia.com/licensing']) . '</p>',
+    ];
+    $form['application_id'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Application ID'),
       '#description' => $this->t('The application ID from your Algolia subscription.'),
@@ -98,8 +98,8 @@ class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInt
       '#required' => TRUE,
       '#size' => 60,
       '#maxlength' => 128,
-    );
-    $form['api_key'] = array(
+    ];
+    $form['api_key'] = [
       '#type' => 'textfield',
       '#title' => $this->t('API Key'),
       '#description' => $this->t('The API key from your Algolia subscription.'),
@@ -107,7 +107,7 @@ class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInt
       '#required' => TRUE,
       '#size' => 60,
       '#maxlength' => 128,
-    );
+    ];
     return $form;
   }
 
@@ -121,32 +121,32 @@ class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInt
     catch (\Exception $e) {
       $this->getLogger()->warning('Could not connect to Algolia backend.');
     }
-    $info = array();
+    $info = [];
 
     // Application ID.
-    $info[] = array(
+    $info[] = [
       'label' => $this->t('Application ID'),
       'info' => $this->getApplicationId(),
-    );
+    ];
 
     // API Key.
-    $info[] = array(
+    $info[] = [
       'label' => $this->t('API Key'),
       'info' => $this->getApiKey(),
-    );
+    ];
 
     // Available indexes.
     $indexes = $this->getAlgolia()->listIndexes();
-    $indexes_list = array();
+    $indexes_list = [];
     if (isset($indexes['items'])) {
       foreach ($indexes['items'] as $index) {
         $indexes_list[] = $index['name'];
       }
     }
-    $info[] = array(
+    $info[] = [
       'label' => $this->t('Available Algolia indexes'),
       'info' => implode(', ', $indexes_list),
-    );
+    ];
 
     return $info;
   }
@@ -167,7 +167,7 @@ class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInt
   public function indexItems(IndexInterface $index, array $items) {
     $this->connect($index);
 
-    $objects = array();
+    $objects = [];
     /** @var \Drupal\search_api\Item\ItemInterface[] $items */
     foreach ($items as $id => $item) {
       $objects[$id] = $this->prepareItem($index, $item);
@@ -319,7 +319,7 @@ class SearchApiAlgoliaBackend extends BackendPluginBase implements PluginFormInt
   public function search(QueryInterface $query) {
     // This plugin does not support searching and we therefore just return an empty search result.
     $results = $query->getResults();
-    $results->setResultItems(array());
+    $results->setResultItems([]);
     $results->setResultCount(0);
     return $results;
   }


### PR DESCRIPTION
See link : https://www.drupal.org/node/2678740

First working version for 8.x released.
search_api 8.x-1.0-alpha1
Tested on versions :

drupal 8.1.10
search_api 8.x-1.0-beta2
address 8.x-1.0-rc1

Summary of Test.
Given places nodes, having multi list text and address field.
Tested places nodes are successfully populated to algolia search index.

Test involves :

a.) at search_api gui page, creation of a search_api algolia server "+ Add server"
url: /admin/config/search/search-api/

b.) at search_api gui page, creation of a search_api index "+ Add index"
url: /admin/config/search/search-api/

c.) at search index gui page, specifying which entity_type and bundle. (node & place)
url: admin/config/search/search-api/index/[index-name]/edit

d.) at search index gui page, specifying which fields to add on index.
url: /admin/config/search/search-api/index/nodes2testserver/fields

e.) at search index gui page, populating drupal nodes to algolia index. "Index now"
url: /admin/config/search/search-api/index/[index-name]

f.) at search index gui page, using "Clear all indexed data"
url: /admin/config/search/search-api/index/[index-name]
